### PR TITLE
Correct null-checks

### DIFF
--- a/beta/Infrastructure/Behaviors/ScrollAnimationBehavior.cs
+++ b/beta/Infrastructure/Behaviors/ScrollAnimationBehavior.cs
@@ -12,12 +12,12 @@ namespace beta.Infrastructure.Behaviors
     {
         public static IEnumerable<T> FindVisualChildren<T>(DependencyObject depObj) where T : DependencyObject
         {
-            if (depObj != null)
+            if (depObj is not null)
             {
                 for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
                 {
                     DependencyObject child = VisualTreeHelper.GetChild(depObj, i);
-                    if (child != null && child is T)
+                    if (child is T)
                     {
                         yield return (T)child;
                     }
@@ -112,7 +112,7 @@ namespace beta.Infrastructure.Behaviors
         {
             ScrollViewer scrollViewer = target as ScrollViewer;
 
-            if (scrollViewer != null)
+            if (scrollViewer is not null)
             {
                 scrollViewer.ScrollToVerticalOffset((double)e.NewValue);
             }
@@ -146,13 +146,13 @@ namespace beta.Infrastructure.Behaviors
         {
             var target = sender;
 
-            if (target != null && target is ScrollViewer)
+            if (target is ScrollViewer)
             {
                 ScrollViewer scroller = target as ScrollViewer;
                 scroller.Loaded += new RoutedEventHandler(scrollerLoaded);
             }
 
-            if (target != null && target is ListBox) 
+            if (target is ListBox) 
             {
                 ListBox listbox = target as ListBox;
                 listbox.Loaded += new RoutedEventHandler(listboxLoaded);
@@ -212,7 +212,7 @@ namespace beta.Infrastructure.Behaviors
         {
             ListBox listbox = sender as ListBox;
 
-            if (listbox != null)
+            if (listbox is not null)
             {
                 double scrollTo = 0;
 
@@ -220,7 +220,7 @@ namespace beta.Infrastructure.Behaviors
                 {
                     ListBoxItem tempItem = listbox.ItemContainerGenerator.ContainerFromItem(listbox.Items[i]) as ListBoxItem;
 
-                    if (tempItem != null)
+                    if (tempItem is not null)
                     {
                         scrollTo += tempItem.ActualHeight;
                     }

--- a/beta/Infrastructure/Behaviors/ScrollAnimationBehavior.cs
+++ b/beta/Infrastructure/Behaviors/ScrollAnimationBehavior.cs
@@ -110,12 +110,7 @@ namespace beta.Infrastructure.Behaviors
 
         private static void OnVerticalOffsetChanged(DependencyObject target, DependencyPropertyChangedEventArgs e)
         {
-            ScrollViewer scrollViewer = target as ScrollViewer;
-
-            if (scrollViewer is not null)
-            {
-                scrollViewer.ScrollToVerticalOffset((double)e.NewValue);
-            }
+            (target as ScrollViewer)?.ScrollToVerticalOffset((double)e.NewValue);
         }
 
         #endregion
@@ -146,15 +141,13 @@ namespace beta.Infrastructure.Behaviors
         {
             var target = sender;
 
-            if (target is ScrollViewer)
+            if (target is ScrollViewer scroller)
             {
-                ScrollViewer scroller = target as ScrollViewer;
                 scroller.Loaded += new RoutedEventHandler(scrollerLoaded);
             }
 
-            if (target is ListBox) 
+            if (target is ListBox listbox)
             {
-                ListBox listbox = target as ListBox;
                 listbox.Loaded += new RoutedEventHandler(listboxLoaded);
             }
         }
@@ -210,9 +203,7 @@ namespace beta.Infrastructure.Behaviors
 
         private static void UpdateScrollPosition(object sender)
         {
-            ListBox listbox = sender as ListBox;
-
-            if (listbox is not null)
+            if (sender is ListBox listbox)
             {
                 double scrollTo = 0;
 
@@ -234,7 +225,7 @@ namespace beta.Infrastructure.Behaviors
 
         #region SetEventHandlersForScrollViewer Helper
 
-        private static void SetEventHandlersForScrollViewer(ScrollViewer scroller) 
+        private static void SetEventHandlersForScrollViewer(ScrollViewer scroller)
         {
             scroller.PreviewMouseWheel += new MouseWheelEventHandler(ScrollViewerPreviewMouseWheel);
             scroller.PreviewKeyDown += new KeyEventHandler(ScrollViewerPreviewKeyDown);

--- a/beta/Infrastructure/Behaviors/TextBlockBehaviors.cs
+++ b/beta/Infrastructure/Behaviors/TextBlockBehaviors.cs
@@ -24,7 +24,7 @@ namespace beta.Infrastructure.Behaviors
         {
             var Target = d as TextBlock;
 
-            if (Target != null)
+            if (Target is not null)
             {
                 Target.Inlines.Clear();
                 Target.Inlines.AddRange((System.Collections.IEnumerable)e.NewValue);

--- a/beta/Infrastructure/Behaviors/TextBlockBehaviors.cs
+++ b/beta/Infrastructure/Behaviors/TextBlockBehaviors.cs
@@ -22,9 +22,7 @@ namespace beta.Infrastructure.Behaviors
 
         private static void OnBindableInlinesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var Target = d as TextBlock;
-
-            if (Target is not null)
+            if (d is TextBlock Target)
             {
                 Target.Inlines.Clear();
                 Target.Inlines.AddRange((System.Collections.IEnumerable)e.NewValue);

--- a/beta/Infrastructure/Commands/CopyCommand.cs
+++ b/beta/Infrastructure/Commands/CopyCommand.cs
@@ -9,7 +9,7 @@ namespace beta.Infrastructure.Commands
 
         public override void Execute(object parameter)
         {
-            if (parameter == null) return;
+            if (parameter is null) return;
 
             Clipboard.SetText(parameter.ToString());
         }

--- a/beta/Infrastructure/Commands/NavigateUriCommand.cs
+++ b/beta/Infrastructure/Commands/NavigateUriCommand.cs
@@ -10,7 +10,7 @@ namespace beta.Infrastructure.Commands
 
         public override void Execute(object parameter)
         {
-            if (parameter == null) return;
+            if (parameter is null) return;
 
             Uri uri = null;
             
@@ -20,7 +20,7 @@ namespace beta.Infrastructure.Commands
             if (parameter is string text)
                 Uri.TryCreate(text, UriKind.Absolute, out uri);
 
-            if (uri != null)
+            if (uri is not null)
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = uri.ToString(),

--- a/beta/Infrastructure/Commands/NavigateUriCommand.cs
+++ b/beta/Infrastructure/Commands/NavigateUriCommand.cs
@@ -12,10 +12,7 @@ namespace beta.Infrastructure.Commands
         {
             if (parameter is null) return;
 
-            Uri uri = null;
-            
-            if (parameter is Uri)
-                uri = (Uri)parameter;
+            Uri uri = parameter as Uri;
 
             if (parameter is string text)
                 Uri.TryCreate(text, UriKind.Absolute, out uri);

--- a/beta/Infrastructure/Converters/ChatPlayerHighlightConverter.cs
+++ b/beta/Infrastructure/Converters/ChatPlayerHighlightConverter.cs
@@ -53,7 +53,7 @@ namespace beta.Infrastructure.Converters
                 var inline = enumrator.Current;
                 if (inline is InlineUIContainer ui)
                 {
-                    if (!(ui.Child is Image or GifImage))
+                    if (ui.Child is not (Image or GifImage))
                     {
                         return false;
                     }

--- a/beta/Infrastructure/Converters/ChatPlayerHighlightConverter.cs
+++ b/beta/Infrastructure/Converters/ChatPlayerHighlightConverter.cs
@@ -11,7 +11,7 @@ namespace beta.Infrastructure.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return false;
+            if (value is null) return false;
             var textBlock = (TextBlock)value;
             var inlines = textBlock.Inlines;
 
@@ -43,7 +43,7 @@ namespace beta.Infrastructure.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return false;
+            if (value is null) return false;
             var textBlock = (TextBlock)value;
             var inlines = textBlock.Inlines;
 

--- a/beta/Infrastructure/Converters/ChatUserGroupConverter.cs
+++ b/beta/Infrastructure/Converters/ChatUserGroupConverter.cs
@@ -10,7 +10,7 @@ namespace beta.Infrastructure.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return null;
+            if (value is null) return null;
 
             if (value is PlayerInfoMessage player)
             {

--- a/beta/Infrastructure/Converters/EmojiFormatConverter.cs
+++ b/beta/Infrastructure/Converters/EmojiFormatConverter.cs
@@ -11,7 +11,7 @@ namespace beta.Infrastructure.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return string.Empty;
+            if (value is null) return string.Empty;
             return ":" + value.ToString() + ":";
         }
 

--- a/beta/Infrastructure/Converters/GetPlayerConverter.cs
+++ b/beta/Infrastructure/Converters/GetPlayerConverter.cs
@@ -25,7 +25,7 @@ namespace beta.Infrastructure.Converters
         /// <returns></returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return null;
+            if (value is null) return null;
 
             var playerName = string.Empty;
 
@@ -33,7 +33,7 @@ namespace beta.Infrastructure.Converters
                 return value;
 
             if (value is ChannelMessage channelMessage)
-                if (channelMessage.From != null)
+                if (channelMessage.From is not null)
                     playerName = channelMessage.From;
                 else return null;
 
@@ -48,7 +48,7 @@ namespace beta.Infrastructure.Converters
             }
 
             var playerInstance = PlayersService.GetPlayer(playerName);
-            if (playerInstance == null)
+            if (playerInstance is null)
             {
                 return new UnknownPlayer()
                 {

--- a/beta/Infrastructure/Converters/IsNullConverter.cs
+++ b/beta/Infrastructure/Converters/IsNullConverter.cs
@@ -14,7 +14,7 @@ namespace beta.Infrastructure.Converters
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value == null;
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value is null;
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/beta/Infrastructure/Converters/MoreThanConverter.cs
+++ b/beta/Infrastructure/Converters/MoreThanConverter.cs
@@ -10,8 +10,13 @@ namespace beta.Infrastructure.Converters
         {
             int num = 0;
             if (value is string text)
+            {
                 num = text.Length;
-            else num = System.Convert.ToInt32(value);
+            }
+            else
+            {
+                num = System.Convert.ToInt32(value);
+            }
 
             if (parameter is null)
                 return num > 0;

--- a/beta/Infrastructure/Converters/MoreThanConverter.cs
+++ b/beta/Infrastructure/Converters/MoreThanConverter.cs
@@ -13,7 +13,7 @@ namespace beta.Infrastructure.Converters
                 num = text.Length;
             else num = System.Convert.ToInt32(value);
 
-            if (parameter == null)
+            if (parameter is null)
                 return num > 0;
             return num > int.Parse(parameter.ToString());
         }

--- a/beta/Infrastructure/Converters/TextConverter.cs
+++ b/beta/Infrastructure/Converters/TextConverter.cs
@@ -186,8 +186,7 @@ namespace beta.Infrastructure.Converters
         }
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is null ) return null;
-            var text = value as string;
+            if (value is not string text) return null;
             IList<Inline> Inlines = new List<Inline>();
 
             StringBuilder textBuilder = new();

--- a/beta/Infrastructure/Converters/TextConverter.cs
+++ b/beta/Infrastructure/Converters/TextConverter.cs
@@ -186,7 +186,7 @@ namespace beta.Infrastructure.Converters
         }
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return null;
+            if (value is null ) return null;
             var text = value as string;
             IList<Inline> Inlines = new List<Inline>();
 
@@ -275,7 +275,7 @@ namespace beta.Infrastructure.Converters
                     {
                         var login = sb.ToString().Substring(1).Replace(" ", "");
                         var player = PlayersService.GetPlayer(login);
-                        if (player != null)
+                        if (player is not null)
                         {
                             Inlines.Add(new InlineUIContainer()
                             {

--- a/beta/Infrastructure/Converters/ToGlyphsTextConverter.cs
+++ b/beta/Infrastructure/Converters/ToGlyphsTextConverter.cs
@@ -8,7 +8,7 @@ namespace beta.Infrastructure.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return "!Null";
+            if (value is null) return "!Null";
             var text = value.ToString();
             return text.Length == 0 ? ' ' : text;
         }

--- a/beta/Infrastructure/Converters/WidthToRowsConverter.cs
+++ b/beta/Infrastructure/Converters/WidthToRowsConverter.cs
@@ -8,7 +8,7 @@ namespace beta.Infrastructure.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null) return 1;
+            if (value is null) return 1;
 
             var width = (double)value;
 

--- a/beta/Infrastructure/Services/ApiService.cs
+++ b/beta/Infrastructure/Services/ApiService.cs
@@ -21,7 +21,7 @@ namespace beta.Infrastructure.Services
 
             client.DefaultRequestHeaders.Add("User-Agent", "FAF Client");
             var token = Properties.Settings.Default.access_token;
-            if (token != null)
+            if (token is not null)
             {
                 client.DefaultRequestHeaders.Add("Authorization", "Bearer token");
             }
@@ -37,7 +37,7 @@ namespace beta.Infrastructure.Services
                 using HttpRequestMessage request = new(HttpMethod.Get, "https://api.faforever.com/" + path);
 
                 var token = Properties.Settings.Default.access_token;
-                if (token != null)
+                if (token is not null)
                 {
                     request.Headers.Authorization = new("Bearer", token);
                 }

--- a/beta/Infrastructure/Services/CacheService.cs
+++ b/beta/Infrastructure/Services/CacheService.cs
@@ -10,7 +10,7 @@ namespace beta.Infrastructure.Services
     {
         public BitmapImage GetImage(Uri uri, Folder folder = Folder.Common)
         {
-            if (uri == null)
+            if (uri is null)
                 throw new ArgumentNullException();
 
             var cacheFolder = App.GetPathToFolder(folder);

--- a/beta/Infrastructure/Services/GameLauncherService.cs
+++ b/beta/Infrastructure/Services/GameLauncherService.cs
@@ -37,7 +37,7 @@ namespace beta.Infrastructure.Services
 
         public void JoinGame()
         {
-            if (LastGame != null)
+            if (LastGame is not null)
             {
 
             }
@@ -100,11 +100,11 @@ namespace beta.Infrastructure.Services
         private async Task<bool> ConfirmPatch(FeaturedMod featuredMod)
         {
             var json = await ApiService.GET($"featuredMods/{(int)featuredMod}/files/latest");
-            if (json == null) return false;
+            if (json is null) return false;
 
             var response = JsonSerializer.Deserialize<Record>(json);
 
-            if (response.FeaturedModFiles == null) return false;
+            if (response.FeaturedModFiles is null) return false;
 
             var localPath = App.GetPathToFolder(Models.Folder.ProgramData);
 
@@ -167,7 +167,7 @@ namespace beta.Infrastructure.Services
         {
             var pathToBin = Properties.Settings.Default.PathToGame + "\\bin";
 
-            if (pathToBin == null || pathToBin.Length == 0) return false;
+            if (pathToBin is null || pathToBin.Length == 0) return false;
             if (!Directory.Exists(pathToBin)) return false;
 
             var localPath = App.GetPathToFolder(Models.Folder.ProgramData) + "bin";

--- a/beta/Infrastructure/Services/GamesServices.cs
+++ b/beta/Infrastructure/Services/GamesServices.cs
@@ -108,7 +108,7 @@ namespace beta.Infrastructure.Services
                 var idleGame = idleGames[i];
                 if (idleGame.host == game.host)
                 {
-                    if (game.launched_at != null)
+                    if (game.launched_at is not null)
                     {
                         // game is launched, removing from IdleGames and moving to LiveGames
                         idleGames.RemoveAt(i);
@@ -135,7 +135,7 @@ namespace beta.Infrastructure.Services
 
             #region Processing if game is live
             // if game is live
-            if (game.launched_at != null)
+            if (game.launched_at is not null)
             {
                 for (int i = 0; i < liveGames.Count; i++)
                 {
@@ -157,7 +157,7 @@ namespace beta.Infrastructure.Services
             // if we passed this way, that we didnt found matches in LiveGames
 
             // filling host by player instance
-            //if (game.Host == null)
+            //if (game.Host is null)
             game.Host = PlayersService.GetPlayer(game.host);
 
 
@@ -171,7 +171,7 @@ namespace beta.Infrastructure.Services
                 SuspiciousGames.Add(game);
             }
 
-            if (game.launched_at != null)
+            if (game.launched_at is not null)
             {
                 liveGames.Add(game);
                 return;
@@ -191,7 +191,7 @@ namespace beta.Infrastructure.Services
             // TODO: FIX ME Need to rework player game status
 
             //var playerStatus = GameState.Open;
-            //if (game.launched_at != null)
+            //if (game.launched_at is not null)
             //{
             //    var timeDifference = DateTime.UtcNow - DateTime.UnixEpoch.AddSeconds(game.launched_at.Value);
             //    playerStatus = timeDifference.TotalSeconds < 300 ? GameState.Playing5 : GameState.Playing;
@@ -204,7 +204,7 @@ namespace beta.Infrastructure.Services
                 for (int i = 0; i < valuePair.Value.Length; i++)
                 {
                     var player = PlayersService.GetPlayer(valuePair.Value[i]);
-                    if (player == null)
+                    if (player is null)
                     {
                         players[i] = new UnknownPlayer()
                         {
@@ -214,7 +214,7 @@ namespace beta.Infrastructure.Services
                     }
 
                     //player.GameState = playerStatus;
-                    if (player.Game == null)
+                    if (player.Game is null)
                         player.Game = game;
                     else if (player.Game.uid != game.uid)
                         player.Game = game;

--- a/beta/Infrastructure/Services/IRCService.cs
+++ b/beta/Infrastructure/Services/IRCService.cs
@@ -134,7 +134,7 @@ namespace beta.Infrastructure.Services
         }
         public void Connect(string host, int port)
         {
-            if (ManagedTcpClient != null)
+            if (ManagedTcpClient is not null)
             {
                 ManagedTcpClient.Dispose();
                 ManagedTcpClient = null;

--- a/beta/Infrastructure/Services/MapsService.cs
+++ b/beta/Infrastructure/Services/MapsService.cs
@@ -21,7 +21,7 @@ namespace beta.Infrastructure.Services
 
         private readonly FileSystemWatcher LocalWatcher;
 
-        private string PathToLegacyMaps => Settings.Default.PathToGame != null ? Settings.Default.PathToGame + @"\maps\" : null;
+        private string PathToLegacyMaps => Settings.Default.PathToGame is not null ? Settings.Default.PathToGame + @"\maps\" : null;
         public MapsService(ICacheService cacheService, IApiService apiService)
         {
             CacheService = cacheService;
@@ -49,7 +49,7 @@ namespace beta.Infrastructure.Services
 
         public LocalMapState CheckLocalMap(string name)
         {
-            if (name == null) return LocalMapState.Unknown;
+            if (name is null) return LocalMapState.Unknown;
 
             int? version = null;
             var data = name.Split('.');
@@ -74,7 +74,7 @@ namespace beta.Infrastructure.Services
                 {
                     if (int.TryParse(data[1], out var v))
                     {
-                        if (version == null)
+                        if (version is null)
                         {
                             return LocalMapState.Older;
                         }
@@ -119,7 +119,7 @@ namespace beta.Infrastructure.Services
 
             // Legacy maps stored in vaults, so this is mostly useless code
             // we have to copy original maps to local maps folder as example
-            if (isLegacy && PathToLegacyMaps != null)
+            if (isLegacy && PathToLegacyMaps is not null)
             {
                 pathToMaps = PathToLegacyMaps;
             }
@@ -175,7 +175,7 @@ namespace beta.Infrastructure.Services
                 using (var reader = new StreamReader(pathToMaps + pathToScenario))
                 {
                     string line;
-                    while ((line = reader.ReadLine()) != null)
+                    while ((line = reader.ReadLine()) is not null )
                     {
                         if (counter == 0) break;
 
@@ -204,7 +204,7 @@ namespace beta.Infrastructure.Services
                         string line;
                         int massCounter = 0;
                         int hydroCounter = 0;
-                        while ((line = reader.ReadLine()) != null)
+                        while ((line = reader.ReadLine()) is not null)
                         {
                             if (line.Contains("\'Mass\'"))
                                 massCounter++;

--- a/beta/Infrastructure/Services/OAuthService.cs
+++ b/beta/Infrastructure/Services/OAuthService.cs
@@ -94,7 +94,7 @@ namespace beta.Infrastructure.Services
         {
             try
             {
-                if (data != null)
+                if (data is not null)
                     return HttpClient.PostAsync(requestUri, data).Result.Content.ReadAsStream();
                 return HttpClient.GetStreamAsync(requestUri).Result;
             }
@@ -136,7 +136,7 @@ namespace beta.Infrastructure.Services
                             "scope=openid+offline+public_profile+lobby&" +
                             "state=" + generatedState);
 
-            if (stream == null) return null;
+            if (stream is null) return null;
 
             var streamReader = new StreamReader(stream);
 
@@ -147,7 +147,7 @@ namespace beta.Infrastructure.Services
 
             Logger.LogInformation("Parsing data to get _csrf and login_challenge");
 
-            while ((line = streamReader.ReadLine()) != null)
+            while ((line = streamReader.ReadLine()) is not null)
                 if (_csrf.Length != 0 && login_challenge.Length != 0)
                     break; 
                 else if (line.Contains(nameof(_csrf)))
@@ -178,7 +178,7 @@ namespace beta.Infrastructure.Services
 
             Logger.LogInformation("Parsing data to get consent_challenge");
 
-            while ((line = streamReader.ReadLine()) != null)
+            while ((line = streamReader.ReadLine()) is not null)
                 if (consent_challenge.Length != 0)
                     break;
                 else if (line.Contains(nameof(consent_challenge))) 
@@ -293,7 +293,7 @@ namespace beta.Infrastructure.Services
             Logger.LogInformation("Starting process of authorization");
 
             var code = GetOAuthCode(usernameOrEmail, password);
-            if (code == null)
+            if (code is null)
             {
                 // TODO: invoke some error events?
                 return;
@@ -357,7 +357,7 @@ namespace beta.Infrastructure.Services
                         }
                         cb.Clear();
                         keyword = string.Empty;
-                        if (payload[3] != null)
+                        if (payload[3] is not null)
                         {
                             break;
                         }

--- a/beta/Infrastructure/Services/PlayersService.cs
+++ b/beta/Infrastructure/Services/PlayersService.cs
@@ -74,7 +74,7 @@ namespace beta.Infrastructure.Services
             var foesIds = e.Arg.foes;
 
             // TODO REWRITE?
-            if (friendsIds != null && friendsIds.Length > 0)
+            if (friendsIds is not null && friendsIds.Length > 0)
                 for (int i = 0; i < friendsIds.Length; i++)
                     if (PlayerUIDToId.TryGetValue(friendsIds[i], out var id))
                     {
@@ -86,7 +86,7 @@ namespace beta.Infrastructure.Services
                         }
                     }
 
-            if (foesIds != null && foesIds.Length > 0)
+            if (foesIds is not null && foesIds.Length > 0)
                 for (int i = 0; i < foesIds.Length; i++)
                     if (PlayerUIDToId.TryGetValue(friendsIds[i], out var id))
                     {
@@ -98,7 +98,7 @@ namespace beta.Infrastructure.Services
                         }
                     }
         }
-        private void OnNewPlayer(object sender  , EventArgs<PlayerInfoMessage> e)
+        private void OnNewPlayer(object sender, EventArgs<PlayerInfoMessage> e)
         {
             var player = e.Arg;
             var players = _Players;
@@ -110,13 +110,13 @@ namespace beta.Infrastructure.Services
             var foesIds = FoesIds;
             var me = Me;
 
-            if (me?.clan != null)
+            if (me?.clan is not null)
                 if (player.clan == me.clan) player.RelationShip = PlayerRelationShip.Clan;
 
             if (player.id != me.id)
             {
                 // TODO REWRITE?
-                if (friendsIds != null && friendsIds.Length > 0)
+                if (friendsIds is not null && friendsIds.Length > 0)
                     for (int i = 0; i < friendsIds.Length; i++)
                         if (friendsIds[i] == player.id)
                         {
@@ -124,7 +124,7 @@ namespace beta.Infrastructure.Services
                             break;
                         }
 
-                if (foesIds != null && foesIds.Length > 0)
+                if (foesIds is not null && foesIds.Length > 0)
                     for (int i = 0; i < foesIds.Length; i++)
                         if (foesIds[i] == player.id)
                         {
@@ -144,9 +144,9 @@ namespace beta.Infrastructure.Services
                 var matchedPlayer = players[id];
 
                 // If avatar is changed
-                if (matchedPlayer.avatar != null)
+                if (matchedPlayer.avatar is not null)
                 {
-                    if (player.avatar != null)
+                    if (player.avatar is not null)
                     {
                         if (player.avatar.url.Segments[^1] != matchedPlayer.avatar.url.Segments[^1])
                             // TODO FIX ME Thread access error. BitmapImage should be created in UI thread
@@ -163,7 +163,7 @@ namespace beta.Infrastructure.Services
                 int count = players.Count;
 
                 // Check for avatar
-                if (player.avatar != null)
+                if (player.avatar is not null)
                 {
                     // TODO FIX ME Thread access error. BitmapImage should be created in UI thread
                     System.Windows.Application.Current.Dispatcher.Invoke(() => player.Avatar = AvatarService.GetAvatar(player.avatar.url),

--- a/beta/Infrastructure/Services/SessionService.cs
+++ b/beta/Infrastructure/Services/SessionService.cs
@@ -128,7 +128,7 @@ namespace beta.Infrastructure.Services
             //Logger.LogInformation($"TCP client is connected? {Client.TcpClient.Connected}");
 #endif
             // TODO Fix
-            if (Client == null)
+            if (Client is null)
             {
                 Client = new(port: 8002)
                 {

--- a/beta/Infrastructure/Services/SocialService.cs
+++ b/beta/Infrastructure/Services/SocialService.cs
@@ -68,7 +68,7 @@ namespace beta.Infrastructure.Services
             string json = $"{{ \"command\":\"{command}\", \"{relation.ToString().ToLower()}\": {id} }}";
 
             var player = PlayersService.GetPlayer(id);
-            if (player != null)
+            if (player is not null)
             {
                 if (command == "social_remove")
                     relation = PlayerRelationShip.None;

--- a/beta/Infrastructure/Utils/ImageTools.cs
+++ b/beta/Infrastructure/Utils/ImageTools.cs
@@ -114,7 +114,7 @@ namespace beta.Infrastructure.Utils
             try
             {
                 Stream smarket = bmp.StreamSource; ;
-                if (smarket != null && smarket.Length > 0)
+                if (smarket is not null && smarket.Length > 0)
                 {
                     //Set the current location
                     smarket.Position = 0;
@@ -151,7 +151,7 @@ namespace beta.Infrastructure.Utils
             Bitmap img = null;
             try
             {
-                if (bytes != null && bytes.Length != 0)
+                if (bytes is not null && bytes.Length != 0)
                 {
                     MemoryStream ms = new MemoryStream(bytes);
                     img = new Bitmap(ms);

--- a/beta/Infrastructure/Utils/Tools.cs
+++ b/beta/Infrastructure/Utils/Tools.cs
@@ -17,11 +17,12 @@ namespace beta.Infrastructure.Utils
             // confirm parent and name are valid.
             if (parent is null || string.IsNullOrEmpty(name)) return null;
 
-            if (parent is FrameworkElement && (parent as FrameworkElement).Name == name) return parent;
+
+            if ((parent as FrameworkElement)?.Name == name) return parent;
 
             DependencyObject result = null;
 
-            if (parent is FrameworkElement) (parent as FrameworkElement).ApplyTemplate();
+            (parent as FrameworkElement)?.ApplyTemplate();
 
             int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
             for (int i = 0; i < childrenCount; i++)
@@ -46,7 +47,7 @@ namespace beta.Infrastructure.Utils
 
             DependencyObject foundChild = null;
 
-            if (parent is FrameworkElement) (parent as FrameworkElement).ApplyTemplate();
+            (parent as FrameworkElement)?.ApplyTemplate();
 
             int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
             for (int i = 0; i < childrenCount; i++)

--- a/beta/Infrastructure/Utils/Tools.cs
+++ b/beta/Infrastructure/Utils/Tools.cs
@@ -15,7 +15,7 @@ namespace beta.Infrastructure.Utils
         public static DependencyObject FindChild(DependencyObject parent, string name)
         {
             // confirm parent and name are valid.
-            if (parent == null || string.IsNullOrEmpty(name)) return null;
+            if (parent is null || string.IsNullOrEmpty(name)) return null;
 
             if (parent is FrameworkElement && (parent as FrameworkElement).Name == name) return parent;
 
@@ -28,7 +28,7 @@ namespace beta.Infrastructure.Utils
             {
                 var child = VisualTreeHelper.GetChild(parent, i);
                 result = FindChild(child, name);
-                if (result != null) break;
+                if (result is not null) break;
             }
 
             return result;
@@ -41,7 +41,7 @@ namespace beta.Infrastructure.Utils
             where T : DependencyObject
         {
             // confirm parent is valid.
-            if (parent == null) return null;
+            if (parent is null) return null;
             if (parent is T) return parent as T;
 
             DependencyObject foundChild = null;
@@ -53,7 +53,7 @@ namespace beta.Infrastructure.Utils
             {
                 var child = VisualTreeHelper.GetChild(parent, i);
                 foundChild = FindChild<T>(child);
-                if (foundChild != null) break;
+                if (foundChild is not null) break;
             }
 
             return foundChild as T;

--- a/beta/Models/API/ApiVaultMeta.cs
+++ b/beta/Models/API/ApiVaultMeta.cs
@@ -77,9 +77,9 @@ namespace beta.Models.API
         {
             get
             {
-                if (_AuthorLogin != null) return _AuthorLogin;
+                if (_AuthorLogin is not null) return _AuthorLogin;
 
-                if (AuthorData != null)
+                if (AuthorData is not null)
                 {
                     _AuthorLogin = AuthorData["login"];
                     AuthorData = null;
@@ -99,7 +99,7 @@ namespace beta.Models.API
             get
             {
                 var desc = MapData?["description"];
-                if (desc == null) return null;
+                if (desc is null) return null;
 
                 var del = desc.IndexOf('>');
 
@@ -114,7 +114,7 @@ namespace beta.Models.API
         {
             get
             {
-                if (MapData?["width"] == null) return null;
+                if (MapData?["width"] is null) return null;
 
                 return Tools.CalculateMapSizeToKm(int.Parse(MapData["width"]));
             }
@@ -123,7 +123,7 @@ namespace beta.Models.API
         {
             get
             {
-                if (MapData?["height"] == null) return null;
+                if (MapData?["height"] is null) return null;
 
                 return Tools.CalculateMapSizeToKm(int.Parse(MapData["height"]));
             }
@@ -138,9 +138,9 @@ namespace beta.Models.API
 
         public Dictionary<string, string> ReviewsSummaryData { get; set; }
         #region Reviews summary getters
-        public double SummaryPositive => ReviewsSummaryData?["positive"] == null ? 0 : double.Parse(ReviewsSummaryData["positive"].Replace('.', ','));
-        public int SummaryReviews => ReviewsSummaryData?["reviews"] == null ? 0 : int.Parse(ReviewsSummaryData["reviews"]);
-        public double SummaryScore => ReviewsSummaryData?["score"] == null ? 0 : double.Parse(ReviewsSummaryData["score"].Replace('.', ','));
+        public double SummaryPositive => ReviewsSummaryData?["positive"] is null ? 0 : double.Parse(ReviewsSummaryData["positive"].Replace('.', ','));
+        public int SummaryReviews => ReviewsSummaryData?["reviews"] is null ? 0 : int.Parse(ReviewsSummaryData["reviews"]);
+        public double SummaryScore => ReviewsSummaryData?["score"] is null ? 0 : double.Parse(ReviewsSummaryData["score"].Replace('.', ','));
         public double SummaryLowerBound => double.TryParse(ReviewsSummaryData?["lowerBound"].Replace('.', ',').Replace("null", null), out var result) ? result : 0;
         public double SummaryFiveRate => SummaryLowerBound != 0 ? 5 * SummaryLowerBound : -1;
         #endregion
@@ -181,7 +181,7 @@ namespace beta.Models.API
 
         public Dictionary<string, string> GetAttributesFromIncluded(ApiDataType type, int id)
         {
-            if (Included == null) return null;
+            if (Included is null) return null;
 
             for (int i = 0; i < Included.Length; i++)
             {

--- a/beta/Models/GameMap.cs
+++ b/beta/Models/GameMap.cs
@@ -48,8 +48,7 @@ namespace beta.Models
         {
             get
             {
-                var desc = Scenario?["description"];
-                if (desc is not null)
+                if (Scenario?["description"] is string desc)
                 {
                     var isArr = desc.IndexOf('>');
                     if (isArr != -1)
@@ -63,9 +62,7 @@ namespace beta.Models
         {
             get
             {
-                var size = Scenario?["size"];
-
-                if (size is null) return null;
+                if (Scenario?["size"] is not string size) return null;
 
                 var sizes = size.Replace(" ", string.Empty).Split(',');
 

--- a/beta/Models/GameMap.cs
+++ b/beta/Models/GameMap.cs
@@ -49,7 +49,7 @@ namespace beta.Models
             get
             {
                 var desc = Scenario?["description"];
-                if (desc != null)
+                if (desc is not null)
                 {
                     var isArr = desc.IndexOf('>');
                     if (isArr != -1)
@@ -65,7 +65,7 @@ namespace beta.Models
             {
                 var size = Scenario?["size"];
 
-                if (size == null) return null;
+                if (size is null) return null;
 
                 var sizes = size.Replace(" ", string.Empty).Split(',');
 

--- a/beta/Models/IRC/IrcCommands.cs
+++ b/beta/Models/IRC/IrcCommands.cs
@@ -46,7 +46,7 @@ namespace beta.Models.IRC
         /// <param name="keys"></param>
         /// <returns></returns>
         internal static string Join(string[] channels, string[] keys = null) =>
-            "JOIN " + string.Join(',', channels) + " " + keys != null ? string.Join(',', keys) : null;
+            "JOIN " + string.Join(',', channels) + " " + keys is not null ? string.Join(',', keys) : null;
         /// <summary>
         /// Causes a user to leave the channel
         /// </summary>

--- a/beta/Models/IrcClient.cs
+++ b/beta/Models/IrcClient.cs
@@ -207,7 +207,7 @@ namespace beta.Models
         /// </summary>
         public void Disconnect()
         {
-            if (TcpClient != null)
+            if (TcpClient is not null)
             {
                 if (TcpClient.Connected)
                 {
@@ -222,7 +222,7 @@ namespace beta.Models
         /// <param name="channel">Channel to join</param>
         public void JoinChannel(string channel)
         {
-            if (TcpClient != null && TcpClient.Connected)
+            if (TcpClient is not null && TcpClient.Connected)
             {
                 Send("JOIN " + channel);
             }
@@ -281,8 +281,8 @@ namespace beta.Models
         /// 
         private void Listen()
         {
-            //if (TcpClient == null) return;
-            //if (TcpClient.Connected == false) return;
+            //if (TcpClient is null) return;
+            //if (TcpClient.Connected is false) return;
 
             var c = TcpClient;
 

--- a/beta/Models/ManagedTcpClient.cs
+++ b/beta/Models/ManagedTcpClient.cs
@@ -85,7 +85,7 @@ namespace beta.Models
         }
         public void Write(byte[] data)
         {
-            if (TcpClient == null)
+            if (TcpClient is null)
             {
                 throw new Exception("Cannot send data to a null TcpClient (check to see if Connect was called)");
             }
@@ -174,7 +174,7 @@ namespace beta.Models
             finally
             {
                 OnStateChanged(ManagedTcpClientState.Disconnected);
-                if (TcpClient != null)
+                if (TcpClient is not null)
                 {
                     Stream.Dispose();
                     TcpClient.Close();
@@ -186,7 +186,7 @@ namespace beta.Models
         #region Private
         private void StartListenThread()
         {
-            if (TcpThread != null) { return; }
+            if (TcpThread is not null) { return; }
 
             TcpThread = new Thread(ListenerLoop)
             {
@@ -210,8 +210,8 @@ namespace beta.Models
         {
             var c = TcpClient;
 
-            if (c == null) return;
-            if (c.Connected == false) return;
+            if (c is null) return;
+            if (!c.Connected) return;
 
             int bytesAvailable = c.Available;
             if (bytesAvailable == 0)

--- a/beta/Models/NewsItem.cs
+++ b/beta/Models/NewsItem.cs
@@ -17,7 +17,7 @@ namespace beta.Models
         {
             get
             {
-                if (_BitmapImage == null)
+                if (_BitmapImage is null)
                 {
                     _BitmapImage = new BitmapImage(MediaUri, new(System.Net.Cache.RequestCacheLevel.NoCacheNoStore));
                     _BitmapImage.DownloadCompleted += (s, e) => OnPropertyChanged(nameof(ImageVisibility));

--- a/beta/Models/ObservableDictionary.cs
+++ b/beta/Models/ObservableDictionary.cs
@@ -228,13 +228,13 @@ namespace beta.Models
 
         protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {
-            if (CollectionChanged != null)
+            if (CollectionChanged is not null)
                 CollectionChanged(this, args);
         }
 
         protected virtual void OnPropertyChanged(string name)
         {
-            if (PropertyChanged != null)
+            if (PropertyChanged is not null)
                 PropertyChanged(this, new PropertyChangedEventArgs(name));
         }
 
@@ -492,7 +492,7 @@ namespace beta.Models
 
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
         {
-            if (array == null)
+            if (array is null)
             {
                 throw new ArgumentNullException("CopyTo() failed:  array parameter was null");
             }
@@ -572,7 +572,7 @@ namespace beta.Models
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
+            if (info is null)
             {
                 throw new ArgumentNullException("info");
             }
@@ -589,7 +589,7 @@ namespace beta.Models
 
         public virtual void OnDeserialization(object sender)
         {
-            if (_siInfo != null)
+            if (_siInfo is not null)
             {
                 Collection<DictionaryEntry> entries = (Collection<DictionaryEntry>)
                     _siInfo.GetValue("entries", typeof(Collection<DictionaryEntry>));

--- a/beta/Models/Server/GameInfoMessage.cs
+++ b/beta/Models/Server/GameInfoMessage.cs
@@ -30,7 +30,7 @@ namespace beta.Models.Server
         {
             get
             {
-                if (Players == null || Players.Length == 0) return 0;
+                if (Players is null || Players.Length == 0) return 0;
                 int sum = 0;
                 for (int i = 0; i < Players.Length; i++)
                     if (Players[i] is PlayerInfoMessage player)
@@ -191,7 +191,7 @@ namespace beta.Models.Server
         {
             get
             {
-                if (_Teams == null || _Teams.Length == 0) return 0;
+                if (_Teams is null || _Teams.Length == 0) return 0;
                 int sum = 0;
                 for (int i = 0; i < _Teams.Length; i++)
                     sum += _Teams[i].AverageRating;
@@ -229,7 +229,7 @@ namespace beta.Models.Server
                 //switch (Map)
                 //{
                 //    case GameMap gameMap:
-                if (Map.Name != null) return Map.Name;
+                if (Map.Name is not null) return Map.Name;
                 else
                 {
                     var parts = _mapname.Split('.')[0].Split('_');

--- a/beta/Models/Server/PlayerInfoMessage.cs
+++ b/beta/Models/Server/PlayerInfoMessage.cs
@@ -113,12 +113,12 @@ namespace beta.Models.Server
             {
                 if (Set(ref _Game, value))
                 {
-                    if (value == null)
+                    if (value is null)
                     {
                         GameState = GameState.None;
                         return;
                     }
-                    if (value.launched_at != null)
+                    if (value.launched_at is not null)
                     {
                         var timeDifference = DateTime.UtcNow - DateTime.UnixEpoch.AddSeconds(value.launched_at.Value);
                         GameState = timeDifference.TotalSeconds < 300 ? GameState.Playing5 : GameState.Playing;
@@ -200,12 +200,12 @@ namespace beta.Models.Server
             {
                 if (value != _ratings)
                 {
-                    if (_ratings != null)
+                    if (_ratings is not null)
                         foreach (var item in value)
                         {
                             if (_ratings.TryGetValue(item.Key, out Rating rating))
                             {
-                                if (rating == null) continue;
+                                if (rating is null) continue;
                                 rating.RatingDifference[0] += item.Value.rating[0] - rating.rating[0];
                                 rating.RatingDifference[1] += item.Value.rating[1] - rating.rating[1];
                                 rating.GamesDifference++;

--- a/beta/Properties/Annotations.cs
+++ b/beta/Properties/Annotations.cs
@@ -75,7 +75,7 @@ namespace beta.Properties
   /// public void Foo([ItemNotNull]List&lt;string&gt; books)
   /// {
   ///   foreach (var book in books) {
-  ///     if (book != null) // Warning: Expression is always true
+  ///     if (book is not null) // Warning: Expression is always true
   ///      Console.WriteLine(book.ToUpper());
   ///   }
   /// }
@@ -254,7 +254,7 @@ namespace beta.Properties
   /// </summary>
   /// <example><code>
   /// void Foo(string param) {
-  ///   if (param == null)
+  ///   if (param is null)
   ///     throw new ArgumentNullException("par"); // Warning: Cannot resolve symbol
   /// }
   /// </code></example>

--- a/beta/Resources/Controls/CrossFadeContentControl.cs
+++ b/beta/Resources/Controls/CrossFadeContentControl.cs
@@ -122,7 +122,7 @@ namespace beta.Resources.Controls
             _oldContentPresenter = _firstContentPresenter;
             _useFirstAsNew = true;
 
-            if (Content != null)
+            if (Content is not null)
             {
                 OnContentChanged(null, Content);
             }
@@ -139,13 +139,13 @@ namespace beta.Resources.Controls
         {
             base.OnContentChanged(oldContent, newContent);
 
-            if (_pendingTransition != null)
+            if (_pendingTransition is not null)
             {
                 _pendingTransition.Abort();
                 _pendingTransition = null;
             }
 
-            if (_fadeOutAnimation != null)
+            if (_fadeOutAnimation is not null)
             {
                 _fadeOutAnimation.Completed -= OnFadeOutAnimationCompleted;
                 _fadeOutAnimation = null;
@@ -155,17 +155,17 @@ namespace beta.Resources.Controls
 
             // Require the appropriate template parts plus a new element to
             // transition to.
-            if (_firstContentPresenter == null || _secondContentPresenter == null || newContent is not UIElement newElement)
+            if (_firstContentPresenter is null || _secondContentPresenter is null || newContent is not UIElement newElement)
             {
                 return;
             }
 
-            if (oldElement != null)
+            if (oldElement is not null)
             {
                 FlipPresenters();
             }
 
-            bool useTransition = oldElement != null && Animates;
+            bool useTransition = oldElement is not null && Animates;
 
             _newContentPresenter.Opacity = useTransition ? 0 : 1;
             _newContentPresenter.Visibility = Visibility.Visible;
@@ -194,7 +194,7 @@ namespace beta.Resources.Controls
 
         private void OnFadeOutAnimationCompleted(object sender, EventArgs e)
         {
-            if (_oldContentPresenter != null)
+            if (_oldContentPresenter is not null)
             {
                 _oldContentPresenter.Visibility = Visibility.Collapsed;
                 _oldContentPresenter.Content = null;

--- a/beta/Resources/Controls/TestControl.xaml.cs
+++ b/beta/Resources/Controls/TestControl.xaml.cs
@@ -492,7 +492,7 @@ namespace beta.Resources.Controls
 
                 SuggestedPlayers.Clear();
 
-                if (Users != null)
+                if (Users is not null)
                     for (int i = 0; i < Users.Count; i++)
                     {
                         if (Users[i].StartsWith(completionText))
@@ -552,7 +552,7 @@ namespace beta.Resources.Controls
             {
                 if (Set(ref _SelectedCommand, value))
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         ObservableDictionary<string, string> commandValues = new();
                         for (int i = 0; i < value.Fields.Length; i++)

--- a/beta/Resources/Controls/TestControl.xaml.cs
+++ b/beta/Resources/Controls/TestControl.xaml.cs
@@ -23,7 +23,7 @@ namespace beta.Resources.Controls
         Player,
         Emoji
     }
-    public abstract class ChatCommand  
+    public abstract class ChatCommand
     {
         public string Name { get; }
         public string Description { get; }
@@ -79,7 +79,7 @@ namespace beta.Resources.Controls
     {
         #region INPC
         public event PropertyChangedEventHandler PropertyChanged;
-        private protected void OnPropertyChanged([CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new(propertyName)); 
+        private protected void OnPropertyChanged([CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new(propertyName));
         protected virtual bool Set<T>(ref T field, T value, [CallerMemberName] string PropertyName = null)
         {
             if (Equals(field, value)) return false;
@@ -106,7 +106,7 @@ namespace beta.Resources.Controls
             {
                 if (Set(ref _SelectedChannel, value))
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         Users = value.Users;
                     }
@@ -164,7 +164,7 @@ namespace beta.Resources.Controls
 
                 if (_InputMode == InputMode.Command)
                 {
-                    if (_SelectedCommand != null)
+                    if (_SelectedCommand is not null)
                     {
                         if (!IsCommandSelected)
                         {
@@ -198,7 +198,7 @@ namespace beta.Resources.Controls
 
                             if (command.Code == IrcUserCommand.PART)
                             {
-                                // SelectedChannel != null;
+                                // SelectedChannel is not null;
                                 OnLeaveRequired();
                                 // SelectedChannel = null;
                             }
@@ -215,9 +215,9 @@ namespace beta.Resources.Controls
                     IrcService.SendMessage(SelectedChannel.Name, CurrentText);
                 }
                 CurrentText = string.Empty;
-                e.Handled = true;   
+                e.Handled = true;
             }
-                
+
             if (e.Key == Key.Down)
             {
                 if (AutoCompletionEnabled)
@@ -331,7 +331,7 @@ namespace beta.Resources.Controls
                             }
                         }
                         OnPropertyChanged(nameof(CommandsHelperVisibility));
-                        if (SuggestedCommands.Count > 0 && SelectedCommand == null) SelectedCommandIndex = 0;
+                        if (SuggestedCommands.Count > 0 && SelectedCommand is null) SelectedCommandIndex = 0;
 
                         var writtenValues = value[WrittenCommand.Length..].Trim();
 
@@ -340,7 +340,7 @@ namespace beta.Resources.Controls
                             var values = writtenValues.Split(' ');
                             int i = 0;
 
-                            if (SelectedCommandFields != null)
+                            if (SelectedCommandFields is not null)
                             {
                                 SelectedCommandFields.Clear();
 
@@ -358,7 +358,7 @@ namespace beta.Resources.Controls
                         }
                         else
                         {
-                            if (SelectedCommandFields != null)
+                            if (SelectedCommandFields is not null)
                             {
                                 SelectedCommandFields.Clear();
                                 for (int j = 0; j < SelectedCommand?.Fields.Length; j++)
@@ -436,7 +436,7 @@ namespace beta.Resources.Controls
             {
                 if (Set(ref _SelectedPlayer, value))
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         CurrentText = completionLine + value;
                         RichTextBox.SelectionStart = _CurrentText.Length;

--- a/beta/Views/ChatView.xaml.cs
+++ b/beta/Views/ChatView.xaml.cs
@@ -74,7 +74,7 @@ namespace beta.Views
                     OnPropertyChanged(nameof(SelectedChannel));
                     UpdateSelectedChannelUsers();
 
-                    //if (value != null)
+                    //if (value is not null)
                     //    TestInputControl.Users = value.Users;
                     TestInputControl.SelectedChannel = value;
                 }
@@ -245,7 +245,7 @@ namespace beta.Views
                 i++;
             }
 
-            if (SelectedChannel == null)
+            if (SelectedChannel is null)
             {
                 //i--;
                 //if ()
@@ -277,7 +277,7 @@ namespace beta.Views
             if (isChatMod) user = user.Substring(1);
 
             var player = PlayersService.GetPlayer(user);
-            if (player != null)
+            if (player is not null)
             {
                 player.IsChatModerator = isChatMod;
                 return player;
@@ -297,7 +297,7 @@ namespace beta.Views
             // TODO Check for duplicates someday... I saw two players on visual users list
             players.Clear();
 
-            if (SelectedChannel == null) return;
+            if (SelectedChannel is null) return;
 
             var users = SelectedChannel.Users;
 
@@ -438,8 +438,7 @@ namespace beta.Views
             {
                 channel.Users.Add(e.Arg.Users[i]);
             }
-
-            if (SelectedChannel == null)
+            if (SelectedChannel is null)
             {
                 SelectedChannel = channel;
             }

--- a/beta/Views/GlobalView.xaml.cs
+++ b/beta/Views/GlobalView.xaml.cs
@@ -332,7 +332,7 @@ namespace beta.Views
         public ICommand RemoveKeyWordCommand => _RemoveKeyWordCommand;
         public void OnRemoveKeyWordCommand(object parameter)
         {
-            if (parameter == null) return;
+            if (parameter is null) return;
             MapsBlackList.Remove(parameter.ToString());
 
             if (_IsMapsBlacklistEnabled)

--- a/beta/Views/Windows/MainWindow.xaml.cs
+++ b/beta/Views/Windows/MainWindow.xaml.cs
@@ -80,7 +80,7 @@ namespace beta.Views.Windows
 
             if (e == ManagedTcpClientState.Connected)
             {
-                if (Dialog != null)
+                if (Dialog is not null)
                     Dialog.Hide();
             }
         }

--- a/beta/Views/Windows/Maps.xaml.cs
+++ b/beta/Views/Windows/Maps.xaml.cs
@@ -647,12 +647,12 @@ namespace beta.Views.Windows
                     filter.Append("recommended=='true';");
                 }
 
-                if (MinimumSlots != null)
+                if (MinimumSlots is not null)
                 {
                     filter.Append($"latestVersion.maxPlayers=ge='{MinimumSlots}';");
                 }
 
-                if (MaximumSlots != null)
+                if (MaximumSlots is not null)
                 {
                     filter.Append($"latestVersion.maxPlayers=le='{MaximumSlots}';");
                 }
@@ -705,7 +705,7 @@ namespace beta.Views.Windows
             if (IsSortEnabled)
             {
                 var sortProperty = GetSortProperty();
-                if (sortProperty  != null)
+                if (sortProperty is not null )
                 {
                     query.Append("sort=");
                     if (SelectedSort.Direction == ListSortDirection.Descending)
@@ -725,7 +725,7 @@ namespace beta.Views.Windows
         }
         private void DoRequest()
         {
-            if (RequestThread != null)
+            if (RequestThread is not null)
             {
                 return;
             }
@@ -771,9 +771,9 @@ namespace beta.Views.Windows
 
                     #region Loading data Author / Map / Reviews summaries
                     // it is complicated...
-                    if (data.Included != null)
+                    if (data.Included is not null)
                     {
-                        if (map.Relations.Author?.Data != null)
+                        if (map.Relations.Author?.Data is not null)
                         {
                             var authorId = map.Relations.Author.Data.Id;
                             if (AuthorIdToLogin.TryGetValue(authorId, out var login))
@@ -791,15 +791,15 @@ namespace beta.Views.Windows
                             }
                         }
 
-                        if (map.Relations.LatestVersion?.Data != null)
+                        if (map.Relations.LatestVersion?.Data is not null)
                         {
                             map.MapData = data.GetAttributesFromIncluded(ApiDataType.mapVersion, map.Relations.LatestVersion.Data.Id);
                         }
 
-                        if (map.Relations.ReviewsSummary?.Data != null)
+                        if (map.Relations.ReviewsSummary?.Data is not null)
                         {
                             map.ReviewsSummaryData = data.GetAttributesFromIncluded(ApiDataType.mapReviewsSummary, map.Relations.ReviewsSummary.Data.Id);
-                            if (map.ReviewsSummaryData != null)
+                            if (map.ReviewsSummaryData is not null)
                             {
 
                             }
@@ -813,21 +813,21 @@ namespace beta.Views.Windows
                     // Check if legacy map
                     map.IsLegacyMap = MapsService.IsLegacyMap(map.FolderName);
 
-                    if (map.ThumbnailUrlSmall != null)
+                    if (map.ThumbnailUrlSmall is not null)
                     {
                         // small map preview
                         Dispatcher.Invoke(() => map.MapSmallPreview = CacheService.GetImage(new(map.ThumbnailUrlSmall), Models.Folder.MapsSmallPreviews),
                             System.Windows.Threading.DispatcherPriority.Background);
                     }
 
-                    if (map.ThumbnailUrlLarge != null)
+                    if (map.ThumbnailUrlLarge is not null)
                     {
                         // small big preview
                         Dispatcher.Invoke(() => map.MapLargePreview = CacheService.GetImage(new(map.ThumbnailUrlLarge), Models.Folder.MapsLargePreviews),
                             System.Windows.Threading.DispatcherPriority.Background);
                     }
 
-                    if (map.ThumbnailUrlLarge == null && map.ThumbnailUrlSmall == null)
+                    if (map.ThumbnailUrlLarge is null && map.ThumbnailUrlSmall is null)
                     {
                         Dispatcher.Invoke(() =>
                         {
@@ -868,7 +868,7 @@ namespace beta.Views.Windows
 
         private void OnSearchForAuthorCommand(object parameter)
         {
-            if (parameter == null) return;
+            if (parameter is null) return;
 
             if (parameter.ToString().Length == 0) return;
             if (parameter.ToString() == "Unknown") return;

--- a/beta/Views/Windows/NewsBetaWindow.xaml.cs
+++ b/beta/Views/Windows/NewsBetaWindow.xaml.cs
@@ -76,8 +76,8 @@ namespace beta.Views.Windows
                             switch (type)
                             {
                                 case "title":
-                                    if (news[i] == null)
-                                    news[i] = new()
+                                    
+                                    news[i] ??= new()
                                     {
                                         Title = text
                                     };
@@ -93,13 +93,13 @@ namespace beta.Views.Windows
                                 case "_embedded": news[i].Author = text;
                                     break;
                                 case "source_url":
-                                    if (news[i] == null)
+                                    if (news[i] is null)
                                     {
-                                        if (previous == null)
+                                        if (previous is null)
                                         {
                                             previous = new(text.Replace("\\/", "/"));
                                         }
-                                        if (previous != null)
+                                        if (previous is not null)
                                         {
                                             news[i - 1].MediaUri = previous;
                                             previous = new(text.Replace("\\/", "/"));
@@ -136,7 +136,7 @@ namespace beta.Views.Windows
             
             for (int j = 0; j < news.Length; j++)
             {
-                if (news[j] != null)
+                if (news[j] is not null)
                     Dispatcher.Invoke(() =>
                     News.Add(news[j]));
             }
@@ -164,7 +164,7 @@ namespace beta.Views.Windows
 
         private void OnTestCommand(object parameter)
         {
-            if (parameter == null) return;
+            if (parameter is null) return;
 
             var item = (Border)parameter;
 

--- a/beta/Views/Windows/Window1.xaml.cs
+++ b/beta/Views/Windows/Window1.xaml.cs
@@ -37,13 +37,11 @@ namespace beta.Views.Windows
             // confirm parent and name are valid.
             if (parent is null || string.IsNullOrEmpty(name)) return null;
 
-            //if ((parent as FrameworkElement)?.Name == name) return parent;
-            if (parent is FrameworkElement && (parent as FrameworkElement).Name == name) return parent;
-
+            if ((parent as FrameworkElement)?.Name == name) return parent;
+         
             DependencyObject result = null;
 
-            //(parent as FrameworkElement)?.ApplyTemplate();
-            if (parent is FrameworkElement) (parent as FrameworkElement).ApplyTemplate();
+           (parent as FrameworkElement)?.ApplyTemplate();
 
             int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
             for (int i = 0; i < childrenCount; i++)
@@ -68,7 +66,7 @@ namespace beta.Views.Windows
 
             DependencyObject foundChild = null;
 
-            if (parent is FrameworkElement) (parent as FrameworkElement).ApplyTemplate();
+             (parent as FrameworkElement)?.ApplyTemplate();
 
             int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
             for (int i = 0; i < childrenCount; i++)

--- a/beta/Views/Windows/Window1.xaml.cs
+++ b/beta/Views/Windows/Window1.xaml.cs
@@ -35,12 +35,14 @@ namespace beta.Views.Windows
         public static DependencyObject FindChild(DependencyObject parent, string name)
         {
             // confirm parent and name are valid.
-            if (parent == null || string.IsNullOrEmpty(name)) return null;
+            if (parent is null || string.IsNullOrEmpty(name)) return null;
 
+            //if ((parent as FrameworkElement)?.Name == name) return parent;
             if (parent is FrameworkElement && (parent as FrameworkElement).Name == name) return parent;
 
             DependencyObject result = null;
 
+            //(parent as FrameworkElement)?.ApplyTemplate();
             if (parent is FrameworkElement) (parent as FrameworkElement).ApplyTemplate();
 
             int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
@@ -48,7 +50,7 @@ namespace beta.Views.Windows
             {
                 var child = VisualTreeHelper.GetChild(parent, i);
                 result = FindChild(child, name);
-                if (result != null) break;
+                if (result is not null) break;
             }
 
             return result;
@@ -61,7 +63,7 @@ namespace beta.Views.Windows
             where T : DependencyObject
         {
             // confirm parent is valid.
-            if (parent == null) return null;
+            if (parent is null) return null;
             if (parent is T) return parent as T;
 
             DependencyObject foundChild = null;
@@ -73,7 +75,7 @@ namespace beta.Views.Windows
             {
                 var child = VisualTreeHelper.GetChild(parent, i);
                 foundChild = FindChild<T>(child);
-                if (foundChild != null) break;
+                if (foundChild is not null) break;
             }
 
             return foundChild as T;


### PR DESCRIPTION
Since C# 9.0 should`ve been used **is** and **is not** for null-checking.
Also consider some other changes in there:
[first](https://github.com/4z0t/Ethereal-FAF-Client/commit/a25b95ffefe4ab98dcbefbbca93f63a1c217ce3a#diff-ee4f649466f615799ba9b01ac03c54222df114f34ccff6682a6887531d278ac1R40) and [second](https://github.com/4z0t/Ethereal-FAF-Client/commit/a25b95ffefe4ab98dcbefbbca93f63a1c217ce3a#diff-ee4f649466f615799ba9b01ac03c54222df114f34ccff6682a6887531d278ac1R45)